### PR TITLE
Fix a typo of default server path for PHP

### DIFF
--- a/nox.el
+++ b/nox.el
@@ -116,7 +116,7 @@
     (python-mode . ("pyls"))
     ((js-mode typescript-mode) . ("javascript-typescript-stdio"))
     (sh-mode . ("bash-language-server" "start"))
-    ((php-mode phps-mode) . ("php" "vendor/felixfbecker/anguage-server/bin/php-language-server.php"))
+    ((php-mode phps-mode) . ("php" "vendor/felixfbecker/language-server/bin/php-language-server.php"))
     ((c++-mode c-mode) . ("ccls"))
     ((caml-mode tuareg-mode reason-mode) . ("ocaml-language-server" "--stdio"))
     (ruby-mode . ("solargraph" "socket" "--port" :autoport))


### PR DESCRIPTION
BTW, I suggest using [Intelephense](https://github.com/emacs-lsp/lsp-mode#supported-languages) as default PHP LSP server, since it provides better result compared to `felixfbecker/language-server` .