### PR TITLE
Change PHP default LSP server to intelephense

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Note: suggestion upgrade emacs to 27.x or 28.x, JSON parser much faster, and Nox
 * Ruby's [solargraph][solargraph]
 * Java's [Eclipse JDT Language Server][eclipse-jdt]
 * Bash's [bash-language-server][bash-language-server]
-* PHP's [php-language-server][php-language-server]
+* PHP's [intelephense][intelephense]
 * C/C++'s [ccls][ccls]  ([cquery][cquery] and [clangd][clangd] also work)
 * Haskell's [IDE engine][haskell-ide-engine]
 * Elm's [elm-language-server][elm-language-server]
@@ -326,7 +326,7 @@ lisp:
 [emacs-lsp]: https://github.com/emacs-lsp/lsp-mode
 [emacs-lsp-plugins]: https://github.com/emacs-lsp
 [bash-language-server]: https://github.com/mads-hartmann/bash-language-server
-[php-language-server]: https://github.com/felixfbecker/php-language-server
+[intelephense]: https://github.com/bmewburn/vscode-intelephense
 [company-mode]: https://github.com/company-mode/company-mode
 [cquery]: https://github.com/cquery-project/cquery
 [ccls]: https://github.com/MaskRay/ccls

--- a/nox.el
+++ b/nox.el
@@ -116,7 +116,7 @@
     (python-mode . ("pyls"))
     ((js-mode typescript-mode) . ("javascript-typescript-stdio"))
     (sh-mode . ("bash-language-server" "start"))
-    ((php-mode phps-mode) . ("php" "vendor/felixfbecker/language-server/bin/php-language-server.php"))
+    ((php-mode phps-mode) . ("intelephense" "--stdio"))
     ((c++-mode c-mode) . ("ccls"))
     ((caml-mode tuareg-mode reason-mode) . ("ocaml-language-server" "--stdio"))
     (ruby-mode . ("solargraph" "socket" "--port" :autoport))


### PR DESCRIPTION
Well... theoretically it should just work (with `npm i -g intelephense` ). 

But I meet a problem on my machine:

```
server-notification Mon Mar 30 15:14:19 2020:
(:jsonrpc "2.0" :method "window/logMessage" :params
          (:type 3 :message "Initialising intelephense 1.3.11"))

server-notification Mon Mar 30 15:14:19 2020:
(:jsonrpc "2.0" :method "window/logMessage" :params
          (:type 3 :message "Reading state from /tmp/intelephense/7b860bb7."))

server-reply (id:1) ERROR Mon Mar 30 15:14:19 2020:
(:jsonrpc "2.0" :id 1 :error
          (:code -32603 :message "Request initialize failed with message: Cannot read property 'dataPaths' of null"))

internal Mon Mar 30 15:14:19 2020:
(:message "Connection state changed" :change "killed\n")


----------b---y---e---b---y---e----------
```

Don't sure if it's only my case or not. Need additional help.