### PR TITLE
Turned HIE's "completionSnippetsOn" off by default

### DIFF
--- a/nox.el
+++ b/nox.el
@@ -120,7 +120,7 @@
     ((c++-mode c-mode) . ("ccls"))
     ((caml-mode tuareg-mode reason-mode) . ("ocaml-language-server" "--stdio"))
     (ruby-mode . ("solargraph" "socket" "--port" :autoport))
-    (haskell-mode . ("hie-wrapper"))
+    (haskell-mode . (nox-hie "hie-wrapper" "--lsp"))
     (elm-mode . ("elm-language-server"))
     (kotlin-mode . ("kotlin-language-server"))
     (go-mode . ("gopls"))
@@ -2412,6 +2412,12 @@ If INTERACTIVE, prompt user for details."
   "Eclipse JDT breaks spec and replies with edits as arguments."
   (mapc #'nox--apply-workspace-edit arguments))
 
+;;; HIE specific
+;;;
+(defclass nox-hie (nox-lsp-server) () :documentation "A custom class for HIE.")
+
+(cl-defmethod nox-initialization-options ((server nox-hie))
+  (list :languageServerHaskell (list :completionSnippetsOn :json-false)))
 
 ;;; Utils
 ;;;


### PR DESCRIPTION
Turn off HIE "completionSnippetsOn" by default. When turned on (which is HIE's default), it's rather annoying that snippets place-holders will come along with every user-defined function completion. 
e.g. 
```haskell
oddPlusOne :: Odd n -> Even (S n)
oddPlusOne ${1:Odd n} --when complete oddPlusOne
```
Not sure if this kind of PR is welcomed or not, since it could be done per personal init.el base, but I think it could be a nice default as per NOX's project goal. It's quite alright if this PR is rejected.